### PR TITLE
ci: publish GoReleaser drafts after artifact upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,3 +22,8 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish GitHub release
+        if: ${{ success() }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit "${{ github.ref_name }}" --draft=false --repo "${{ github.repository }}"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -33,3 +33,6 @@ checksum:
 
 changelog:
   sort: asc
+
+release:
+  draft: true


### PR DESCRIPTION
## Summary
- configure GoReleaser to keep GitHub releases as drafts while artifacts are uploaded
- publish the draft release only after the release workflow completes artifact/registry steps
- keep release workflows compatible with GitHub immutable releases

## Verification
- actionlint on changed GoReleaser release workflow
- git diff --check
