### PR TITLE
docs(vectorstore): add examples/minimal/config.yaml

### DIFF
--- a/examples/minimal/config.yaml
+++ b/examples/minimal/config.yaml
@@ -1,0 +1,13 @@
+# Minimal config exercising workflow-plugin-vectorstore.
+# Schema-validate with: wfctl validate --skip-unknown-types examples/minimal/config.yaml
+version: 1
+modules:
+  - name: vectorstore-provider
+    type: vectorstore.provider
+    config: {}
+workflows:
+  pipeline:
+    steps:
+      - name: example
+        type: step.vector_upsert
+        config: {}


### PR DESCRIPTION
Closes the P2-tier examples gap from workflow#714.