### PR TITLE
chore: bump plugin.json v0.1.3 (C5 post-release cleanup)

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "workflow-plugin-vectorstore",
-    "version": "0.1.1",
+    "version": "0.1.3",
     "description": "Vector database integration (Pinecone, Milvus) for RAG pipelines",
     "author": "GoCodeAlone",
     "license": "MIT",


### PR DESCRIPTION
## Summary
- Bumps `plugin.json` version to v0.1.3

## Test plan
- [ ] CI passes on merge
- [ ] Tag v0.1.3 triggers release workflow