### PR TITLE
chore: declare secret target support

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -333,5 +333,53 @@
         }
       ]
     }
+  ],
+  "secret_targets": [
+    {
+      "provider": "github",
+      "scopes": [
+        "repo",
+        "env",
+        "org"
+      ],
+      "description": "Stored as GitHub Actions secrets when workflows run on GitHub."
+    },
+    {
+      "provider": "gitlab",
+      "scopes": [
+        "project",
+        "group",
+        "env"
+      ],
+      "description": "Stored as GitLab CI/CD variables when workflows run on GitLab."
+    },
+    {
+      "provider": "vault",
+      "scopes": [
+        "mount"
+      ],
+      "description": "Stored in Vault for application/runtime retrieval."
+    },
+    {
+      "provider": "file",
+      "scopes": [
+        "directory"
+      ],
+      "description": "Stored in a local file-backed secret store."
+    },
+    {
+      "provider": "keychain",
+      "scopes": [
+        "service"
+      ],
+      "description": "Stored in the local OS keychain."
+    },
+    {
+      "provider": "env",
+      "scopes": [
+        "process"
+      ],
+      "description": "Provided by the local process environment."
+    }
   ]
 }

--- a/plugin.json
+++ b/plugin.json
@@ -334,52 +334,52 @@
       ]
     }
   ],
-  "secret_targets": [
-    {
-      "provider": "github",
-      "scopes": [
-        "repo",
-        "env",
-        "org"
-      ],
-      "description": "Stored as GitHub Actions secrets when workflows run on GitHub."
-    },
-    {
-      "provider": "gitlab",
-      "scopes": [
-        "project",
-        "group",
-        "env"
-      ],
-      "description": "Stored as GitLab CI/CD variables when workflows run on GitLab."
-    },
-    {
-      "provider": "vault",
-      "scopes": [
-        "mount"
-      ],
-      "description": "Stored in Vault for application/runtime retrieval."
-    },
-    {
-      "provider": "file",
-      "scopes": [
-        "directory"
-      ],
-      "description": "Stored in a local file-backed secret store."
-    },
-    {
-      "provider": "keychain",
-      "scopes": [
-        "service"
-      ],
-      "description": "Stored in the local OS keychain."
-    },
-    {
-      "provider": "env",
-      "scopes": [
-        "process"
-      ],
-      "description": "Provided by the local process environment."
-    }
-  ]
+    "secret_targets": [
+      {
+        "provider": "github",
+        "scopes": [
+          "repo",
+          "env",
+          "org"
+        ],
+        "description": "Stored as GitHub Actions secrets when workflows run on GitHub."
+      },
+      {
+        "provider": "gitlab",
+        "scopes": [
+          "project",
+          "group",
+          "env"
+        ],
+        "description": "Stored as GitLab CI/CD variables when workflows run on GitLab."
+      },
+      {
+        "provider": "vault",
+        "scopes": [
+          "mount"
+        ],
+        "description": "Stored in Vault for application/runtime retrieval."
+      },
+      {
+        "provider": "file",
+        "scopes": [
+          "directory"
+        ],
+        "description": "Stored in a local file-backed secret store."
+      },
+      {
+        "provider": "keychain",
+        "scopes": [
+          "service"
+        ],
+        "description": "Stored in the local OS keychain."
+      },
+      {
+        "provider": "env",
+        "scopes": [
+          "process"
+        ],
+        "description": "Provided by the local process environment."
+      }
+    ]
 }


### PR DESCRIPTION
## Summary
- declare supported `secret_targets[]` for plugin required secrets
- include GitHub Actions, GitLab CI/CD variables, Vault, file, keychain, and explicit local env targets

## Verification
- `jq empty plugin.json`
- `git diff --check`
